### PR TITLE
Feat: Add readOnly support to DynamicForm and related widgets

### DIFF
--- a/lib/components/app_snackbar.dart
+++ b/lib/components/app_snackbar.dart
@@ -20,7 +20,9 @@ class AppSnackBar {
     Duration? duration,
     Color? backgroundColor,
   }) {
-    ScaffoldMessenger.of(context).showSnackBar(
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
       SnackBar(
         content: Row(
           children: [

--- a/lib/dynamicform.dart
+++ b/lib/dynamicform.dart
@@ -6753,8 +6753,8 @@ class _FileUploadWidgetState extends State<FileUploadWidget> {
         // More clear spacing before button
         if (shouldShowUploadUI) const SizedBox(height: 12),
 
-        // Upload button - Show it when upload UI should be shown
-        if (shouldShowUploadUI)
+        // Upload button - Show it when upload UI should be shown and not read-only
+        if (shouldShowUploadUI && !widget.readOnly)
           widget.bookingAppModelFileUpload
               ? Column(
                   children: [

--- a/lib/dynamicform.dart
+++ b/lib/dynamicform.dart
@@ -3432,6 +3432,10 @@ class _DynamicFormState extends State<DynamicForm>
   }
 
   Widget _buildSubmitButton(Color buttonColor, bool isManageToCheckPress) {
+    if (widget.readOnly) {
+      // Submit button hidden in read-only mode to prevent triggering submission
+      return const SizedBox.shrink();
+    }
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 10.0),
       child: Row(

--- a/lib/dynamicform.dart
+++ b/lib/dynamicform.dart
@@ -60,6 +60,7 @@ class DynamicForm extends StatefulWidget {
   final Map<String, dynamic>? initialValues;
   final bool accordionView;
   final ThemeData? themeData;
+  final bool readOnly;
 
   DynamicForm({
     required this.formJson,
@@ -83,6 +84,7 @@ class DynamicForm extends StatefulWidget {
     this.draftMode = true,
     this.isDraftVisible = true,
     this.themeData,
+    this.readOnly = false,
     RxBool? draftbtnClicked,
     super.key,
   }) : draftbtnClicked = draftbtnClicked ?? false.obs;
@@ -1754,6 +1756,7 @@ class _DynamicFormState extends State<DynamicForm>
 
             return MultiSelectFormField(
               field: FormFieldModel.fromJson(field),
+              readOnly: widget.readOnly,
               onChanged: (List<String> value) {
                 // Force direct update to the FormGroup's value
                 controller.form.patchValue({field['name']: value});
@@ -1837,7 +1840,7 @@ class _DynamicFormState extends State<DynamicForm>
                   dense: true,
                           groupValue: control.value,
                           activeColor: hasError ? Colors.red : widget.primaryColor,
-                  onChanged: (value) {
+                  onChanged: widget.readOnly ? null : (value) {
                     // Update the form using patchValue instead of directly setting the value
                     // This will ensure that all reactive widgets listening to this field are notified
                     if (value != null) {
@@ -2020,6 +2023,7 @@ class _DynamicFormState extends State<DynamicForm>
                     primaryColor: widget.primaryColor,
                     fontFamily: widget.fontFamily,
                     buttonTextColor: widget.buttonTextColor,
+                    readOnly: widget.readOnly,
                     onFilesUploaded: (files) {
                       setState(() {
                         controller.uploadedFiles[field['name']] = files;
@@ -2077,6 +2081,7 @@ class _DynamicFormState extends State<DynamicForm>
                   ),
                   ReactiveTextField(
                     formControlName: '${field['name']}_comment',
+                    readOnly: widget.readOnly,
                     decoration: InputDecoration(
                         hintText: field['commentHint'] ?? '',
                         labelStyle: widget.fontFamily,
@@ -2126,7 +2131,7 @@ class _DynamicFormState extends State<DynamicForm>
             ? const SizedBox.shrink()
             : const SizedBox(height: 4),
         InkWell(
-          onTap: () {
+          onTap: widget.readOnly ? null : () {
             showModalBottomSheet(
               context: context,
               isScrollControlled: true,
@@ -2314,6 +2319,7 @@ class _DynamicFormState extends State<DynamicForm>
                     primaryColor: widget.primaryColor,
                     fontFamily: widget.fontFamily,
                     buttonTextColor: widget.buttonTextColor,
+                    readOnly: widget.readOnly,
                     onFilesUploaded: (files) {
                       setState(() {
                         controller.uploadedFiles[field['name']] = files;
@@ -2357,6 +2363,7 @@ class _DynamicFormState extends State<DynamicForm>
           ),
           ReactiveTextField(
             formControlName: '${field['name']}_comment',
+            readOnly: widget.readOnly,
             decoration: InputDecoration(
                 // No labelText to avoid displaying "comments" in the field
                 hintText: field['commentHint'] ?? '',
@@ -2440,6 +2447,7 @@ class _DynamicFormState extends State<DynamicForm>
                       _buildLabelRow(field),
                       ReactiveTextField(
                         formControlName: field['name'],
+                        readOnly: widget.readOnly,
                         validationMessages: {
                           'required': (error) {
                             final fieldName = field['name'];
@@ -2522,6 +2530,7 @@ class _DynamicFormState extends State<DynamicForm>
           ),
           ReactiveTextField(
             formControlName: '${field['name']}_comment',
+            readOnly: widget.readOnly,
             decoration: InputDecoration(
                 // No labelText to avoid displaying "comments" in the field
                 hintText: field['commentHint'] ?? '',
@@ -2648,6 +2657,7 @@ class _DynamicFormState extends State<DynamicForm>
                 primaryColor: widget.primaryColor,
                 fontFamily: widget.fontFamily,
                 buttonTextColor: widget.buttonTextColor,
+                readOnly: widget.readOnly,
                 onFilesUploaded: (files) {
                   setState(() {
                     controller.uploadedFiles[field['name']] = files;
@@ -2697,6 +2707,7 @@ class _DynamicFormState extends State<DynamicForm>
               if (controlIsNum) {
                 return ReactiveTextField<num>(
                   formControlName: field['name'],
+                  readOnly: widget.readOnly,
                   keyboardType: TextInputType.number,
                   valueAccessor: NumValueAccessor(),
                   validationMessages: {
@@ -2750,6 +2761,7 @@ class _DynamicFormState extends State<DynamicForm>
               // Fallback to plain TextField bound to String control to avoid type errors
               return TextFormField(
                 initialValue: ctrl.value?.toString() ?? '',
+                readOnly: widget.readOnly,
                 keyboardType: TextInputType.number,
                 onChanged: (val) => ctrl.value = val,
                 inputFormatters: [
@@ -2865,6 +2877,7 @@ class _DynamicFormState extends State<DynamicForm>
           ),
           ReactiveTextField(
             formControlName: '${field['name']}_comment',
+            readOnly: widget.readOnly,
             decoration: InputDecoration(
                 // No labelText to avoid displaying "comments" in the field
                 hintText: field['commentHint'] ?? '',
@@ -2949,6 +2962,7 @@ class _DynamicFormState extends State<DynamicForm>
           TextEditingController(text: ctrl.value?.toString() ?? '0.0');
       return TextFormField(
         controller: textController,
+        readOnly: widget.readOnly,
         keyboardType:
             const TextInputType.numberWithOptions(signed: true, decimal: true),
         inputFormatters: [
@@ -2999,8 +3013,9 @@ class _DynamicFormState extends State<DynamicForm>
 
             return LayoutBuilder(builder: (context, constraints) {
               final isDesktop = constraints.maxWidth > 600;
+              Widget tempWidget;
               if (isDoubleType) {
-                return _buildTempScroller(
+                tempWidget = _buildTempScroller(
                   formControlName: name,
                   min: min,
                   max: max,
@@ -3009,10 +3024,16 @@ class _DynamicFormState extends State<DynamicForm>
                   isDesktop: isDesktop,
                   maxWidth: constraints.maxWidth,
                 );
+              } else {
+                // Fallback: string-backed control — show numeric text field and update control
+                tempWidget = _buildStringFallback(ctrl as FormControl<dynamic>);
               }
-
-              // Fallback: string-backed control — show numeric text field and update control
-              return _buildStringFallback(ctrl as FormControl<dynamic>);
+              
+              // Wrap in IgnorePointer when readOnly to disable interaction
+              if (widget.readOnly) {
+                return IgnorePointer(child: tempWidget);
+              }
+              return tempWidget;
             });
           } catch (e, st) {
             if (kDebugMode) {
@@ -3034,6 +3055,7 @@ class _DynamicFormState extends State<DynamicForm>
           const SizedBox(height: 16),
           ReactiveTextField(
             formControlName: '${name}_comment',
+            readOnly: widget.readOnly,
             decoration: InputDecoration(
               hintText: field['commentHint'] ?? '',
               labelStyle: widget.fontFamily,
@@ -3096,6 +3118,7 @@ class _DynamicFormState extends State<DynamicForm>
                         primaryColor: widget.primaryColor,
                         fontFamily: widget.fontFamily,
                         buttonTextColor: widget.buttonTextColor,
+                        readOnly: widget.readOnly,
                         onFilesUploaded: (files) {
                           setState(() {
                             controller.uploadedFiles[field['name']] = files;
@@ -3207,6 +3230,7 @@ class _DynamicFormState extends State<DynamicForm>
           ),
           ReactiveTextField(
             formControlName: '${field['name']}_comment',
+            readOnly: widget.readOnly,
             decoration: InputDecoration(
                 // No labelText to avoid displaying "comments" in the field
                 hintText: field['commentHint'] ?? '',
@@ -5998,6 +6022,7 @@ class FileUploadWidget extends StatefulWidget {
   final bool hasAttachments; // Add new property
   final bool bookingAppModelFileUpload;
   final Map<String, dynamic>? initialValues;
+  final bool readOnly;
 
   const FileUploadWidget({
     Key? key,
@@ -6014,6 +6039,7 @@ class FileUploadWidget extends StatefulWidget {
     this.hasAttachments = false, // Default to false
     this.bookingAppModelFileUpload = false,
     this.initialValues,
+    this.readOnly = false,
   }) : super(key: key);
 
   @override
@@ -6872,7 +6898,7 @@ class _FileUploadWidgetState extends State<FileUploadWidget> {
                         borderRadius: BorderRadius.circular(8),
                       ),
                     ),
-                    onPressed: () => _pickAndUploadFile(context),
+                    onPressed: widget.readOnly ? null : () => _pickAndUploadFile(context),
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
@@ -6911,7 +6937,7 @@ class _FileUploadWidgetState extends State<FileUploadWidget> {
                 overflow: TextOverflow.ellipsis,
                 maxLines: 1,
               ),
-              trailing: IconButton(
+              trailing: widget.readOnly ? null : IconButton(
                 icon: const Icon(Icons.delete),
                 onPressed: () =>
                     widget.onRemoveUploadedFile(widget.uploadedFiles[0]),

--- a/lib/dynamicform.dart
+++ b/lib/dynamicform.dart
@@ -1112,8 +1112,10 @@ class _DynamicFormState extends State<DynamicForm>
               _shortTextSubmitAttempted &&
               _hasRequiredEmptyFields(anchor);
           final bool isDraft = isAnchorDraft(anchor) && widget.draftMode;
+          final cardKey =
+              _fieldKeys.putIfAbsent(anchor, () => GlobalKey());
           return Card(
-            key: _fieldKeys[anchor],
+            key: cardKey,
             clipBehavior: Clip.hardEdge,
             margin: const EdgeInsets.only(bottom: 8),
             shape: RoundedRectangleBorder(

--- a/lib/widgets/multi_select_form_field.dart
+++ b/lib/widgets/multi_select_form_field.dart
@@ -8,6 +8,7 @@ class MultiSelectFormField extends StatelessWidget {
   final List<String> value;
   final bool hasError;
   final String? errorText;
+  final bool readOnly;
 
   const MultiSelectFormField({
     Key? key,
@@ -16,6 +17,7 @@ class MultiSelectFormField extends StatelessWidget {
     required this.value,
     this.hasError = false,
     this.errorText,
+    this.readOnly = false,
   }) : super(key: key);
 
   void _showMultiSelectBottomSheet(BuildContext context) {
@@ -53,7 +55,7 @@ class MultiSelectFormField extends StatelessWidget {
         // ),
         const SizedBox(height: 8),
         InkWell(
-          onTap: () => _showMultiSelectBottomSheet(context),
+          onTap: readOnly ? null : () => _showMultiSelectBottomSheet(context),
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
             decoration: BoxDecoration(


### PR DESCRIPTION
Introduces a readOnly property to DynamicForm, FileUploadWidget, and MultiSelectFormField, propagating it to relevant child widgets and disabling user interactions when readOnly is true. This allows forms and file uploads to be rendered in a non-editable state, improving support for view-only scenarios.