### PR TITLE
Fix: Update onSubmit callback to accept isDraft and isManageToCheckPress

### DIFF
--- a/lib/dynamicform.dart
+++ b/lib/dynamicform.dart
@@ -34,7 +34,7 @@ import 'widgets/temperature_scroll_widget.dart';
 class DynamicForm extends StatefulWidget {
   final List<Map<String, dynamic>> formJson;
   final Function(
-          Map<String, dynamic>, Map<String, List<Map<String, dynamic>>>, bool?)
+          Map<String, dynamic>, Map<String, List<Map<String, dynamic>>>, bool?, bool?)
       onSubmit;
   final Color primaryColor;
   final Color buttonTextColor;
@@ -3646,7 +3646,7 @@ class _DynamicFormState extends State<DynamicForm>
       final nestedFormData = controller.createNestedStructure(formValue);
 
       try {
-        widget.onSubmit(nestedFormData, controller.uploadedFiles, isDraft);
+        widget.onSubmit(nestedFormData, controller.uploadedFiles, isDraft, isManageToCheckPress);
       } catch (e) {
         if (kDebugMode) {
           print('[DynamicForm] Error calling widget.onSubmit: $e');
@@ -3747,7 +3747,7 @@ class _DynamicFormState extends State<DynamicForm>
 
     // Submit the nested data
     widget.onSubmit(
-        nestedFormData, cleanedUploadedFiles, isDraft);
+        nestedFormData, cleanedUploadedFiles, isDraft, isManageToCheckPress);
   }
 
   /// The function `_findFirstInvalidAnchor` iterates through group anchors and checks for invalid

--- a/lib/dynamicformcontroller.dart
+++ b/lib/dynamicformcontroller.dart
@@ -10,7 +10,7 @@ import 'package:reactiveform/models/form_field_model.dart';
 class DynamicFormController extends ChangeNotifier {
   final List<Map<String, dynamic>> formJson;
   final void Function(
-          Map<String, dynamic>, Map<String, List<Map<String, dynamic>>>, bool)
+          Map<String, dynamic>, Map<String, List<Map<String, dynamic>>>, bool?, bool?)
       onSubmit;
   final Map<String, dynamic>? initialValues;
 
@@ -342,7 +342,7 @@ class DynamicFormController extends ChangeNotifier {
     if (isValid) {
       final formValue = Map<String, dynamic>.from(form.value);
       final nestedFormValue = createNestedStructure(formValue);
-      onSubmit(nestedFormValue, uploadedFiles, isManageToCheckPress);
+      onSubmit(nestedFormValue, uploadedFiles, false, isManageToCheckPress);
     } else {
       form.markAllAsTouched();
       _handleFormErrors(context);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,7 @@ class KitchenInspectionScreen extends StatelessWidget {
           primaryColor: Colors.black,
           formJson: formJson,
           bookingAppModelFileUpload: true,
-          onSubmit: (formData, attachments, bool? isManageToCheckPress) {
+          onSubmit: (formData, attachments, bool? isDraft, bool? isManageToCheckPress) {
             if (kDebugMode) {
               print("Submit button clicked: $formData");
             }


### PR DESCRIPTION
Modified the onSubmit function signature in DynamicForm, DynamicFormController, and KitchenInspectionScreen to accept both isDraft and isManageToCheckPress parameters. This change allows more granular control over form submission states.